### PR TITLE
chore(docs): fix CSS class

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ export default {
 ### Attach classes
 
 The Vue Fixed Header always assigns the `vue-fixed-header` CSS class to the slot's root element.
-Also, when matching the fixed condition, we give the `vue-fixed-header - isFixed` CSS class.
+Also, when matching the fixed condition, we give the `vue-fixed-header--isFixed` CSS class.
 These can also be changed with headerClass prop and fixedClass prop.
 
 ## Props


### PR DESCRIPTION
I fixed CSS class based on the below code.

https://github.com/potato4d/vue-fixed-header/blob/fbcbe3281f53baab82e289f87a25565ac63235c3/src/components/vue-fixed-header.ts#L24